### PR TITLE
Optimize generated flipbooks: avoids serializing images to JSON

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# AGENTS.md
+
+Client-side PDF→3D flipbook converter. Vanilla JS + pdf.js → standalone HTML files.
+
+## Setup
+
+`npm install` | `npm run dev` (port 8000) | `npm run build` → dist/ | `npm test` | `npm start` (build+preview port 3000)
+
+## Architecture
+
+3-tier: processor.js (PDF→canvas→base64 JPEG via pdf.js) → generator.js (embeds CSS/JS/images into single HTML) → app.js (UI/upload/progress). Output: flipbook.js (3D page-turning, lazy load, keyboard/mouse nav), flipbook.css (3D transforms), main.css (UI).
+
+## Code style
+
+ES6 modules, JSDoc types, async/await, no frameworks, individual exports, validate inputs at entry.
+
+## Testing
+
+Node test runner. Tests in test/, fixtures in test/fixtures/. Mock asset loaders. Run before commits.
+
+## Implementation notes
+
+processor.js: Lazy-loads pdf.js (browser=regular, Node=legacy for DOMMatrix). Scale 2x, JPEG 0.92. Returns {pageCount, renderPage}.
+
+generator.js: wrapFlipbookJs() injects page data replacing dataset with window globals. generateFlipbookHtml() accepts assetLoader. Uses ?raw imports for CSS/JS strings.
+
+flipbook.js: Two-page spread (odd=left, even=right), lazy loading with placeholders, 800ms transitions, z-index stacking, arrow keys + click nav.
+
+vite.config.js: Base ./, pdf.js in separate chunk, chunk limit 1000KB, server 8000, preview 3000.
+
+## Dependencies
+
+index.html → app.js → processor.js + generator.js + flipbook.css?raw + flipbook.js?raw. processor.js → pdfjs-dist. Generated HTML embeds all assets as base64.
+
+## Known issues
+
+Large PDFs = large HTML (all pages base64 embedded). Browser limit ~100-200 pages. pdf.js worker needs Vite path resolution. Tests use legacy pdf.js for Node DOM compat.

--- a/src/app.js
+++ b/src/app.js
@@ -128,7 +128,7 @@ class FlipbookApp {
                 loadJs: async () => wrapFlipbookJs(flipbookJs)
             };
             
-            const html = await generateFlipbookHtml(pageCount, pageImages, {
+            const html = await generateFlipbookHtml(pageImages, {
                 title: file.name.replace('.pdf', '')
             }, assetLoader);
             

--- a/src/flipbook.js
+++ b/src/flipbook.js
@@ -7,13 +7,11 @@ class Flipbook {
     /**
      * @param {number} totalPages - Total number of pages
      * @param {HTMLElement[]} pages - Array of page DOM elements
-     * @param {string[]} pageImages - Array of base64 image data URLs
      * @param {number} transitionMs - Transition duration in milliseconds
      */
-    constructor(totalPages, pages, pageImages, transitionMs = 800) {
+    constructor(totalPages, pages, transitionMs = 800) {
         this.totalPages = totalPages;
         this.pages = pages;
-        this.pageImages = pageImages;
         this.transitionMs = transitionMs;
         this.currentPage = 1;
         this.isTurning = false;
@@ -55,8 +53,28 @@ class Flipbook {
             const frontFace = page.querySelector('.page-face-front');
             const backFace = page.querySelector('.page-face-back');
             
-            frontFace.innerHTML = '<div class="loading-placeholder">Page ' + pageNum + '</div>';
-            backFace.innerHTML = '<div class="loading-placeholder">Page ' + pageNum + '</div>';
+            const frontImg = frontFace.querySelector('img');
+            const backImg = backFace.querySelector('img');
+            
+            if (frontImg) {
+                frontImg.style.display = 'none';
+                const placeholder = document.createElement('div');
+                placeholder.className = 'loading-placeholder';
+                placeholder.textContent = 'Page ' + pageNum;
+                frontFace.appendChild(placeholder);
+            } else {
+                frontFace.innerHTML = '<div class="loading-placeholder">Page ' + pageNum + '</div>';
+            }
+            
+            if (backImg) {
+                backImg.style.display = 'none';
+                const placeholder = document.createElement('div');
+                placeholder.className = 'loading-placeholder';
+                placeholder.textContent = 'Page ' + pageNum;
+                backFace.appendChild(placeholder);
+            } else {
+                backFace.innerHTML = '<div class="loading-placeholder">Page ' + pageNum + '</div>';
+            }
         });
     }
 
@@ -80,16 +98,14 @@ class Flipbook {
         const faceEl = pageEl.querySelector('.page-face-' + faceType);
         if (!faceEl) return;
 
-        const imageSrc = this.pageImages[pageIndex - 1];
-        if (!imageSrc) return;
+        const img = faceEl.querySelector('img');
+        if (!img) return;
+
+        const imageSrc = img.src;
 
         this.preloadImage(imageSrc).then(() => {
-            const currentHtml = faceEl.innerHTML || '';
-            const expectedHtml = '<img src="' + imageSrc + '" alt="Page ' + pageIndex + '" loading="eager" />';
-            
-            if (!currentHtml.includes('src="')) {
-                faceEl.innerHTML = expectedHtml;
-            }
+            img.style.display = '';
+            img.setAttribute('loading', 'eager');
         }).catch(() => {
             faceEl.innerHTML = '<div class="loading-placeholder">Failed to load page ' + pageIndex + '</div>';
         });
@@ -254,12 +270,11 @@ class Flipbook {
 
 // Initialize flipbook when DOM is ready
 document.addEventListener('DOMContentLoaded', () => {
-    const totalPages = parseInt(document.getElementById('book-container').dataset.pageCount);
-    const pageImages = JSON.parse(document.getElementById('book-container').dataset.pageImages);
-    const pages = Array.from(document.querySelectorAll('.page'));
     const container = document.getElementById('book-container');
+    const totalPages = parseInt(container?.dataset.pageCount) || window.__PAGE_COUNT__;
+    const pages = Array.from(document.querySelectorAll('.page'));
     
-    window.flipbook = new Flipbook(totalPages, pages, pageImages);
+    window.flipbook = new Flipbook(totalPages, pages);
     console.log('Flipbook initialized. Use Arrow keys or click to turn pages.');
 });
 

--- a/src/generator.js
+++ b/src/generator.js
@@ -49,15 +49,9 @@ export function wrapFlipbookJs(jsContent) {
         throw new Error('jsContent must be a string');
     }
 
-    // Replace the initialization code to inject pageCount and pageImages
     let modifiedJs = jsContent.replace(
         'const totalPages = parseInt(document.getElementById(\'book-container\').dataset.pageCount);',
         'const totalPages = window.__PAGE_COUNT__;'
-    );
-
-    modifiedJs = modifiedJs.replace(
-        'const pageImages = JSON.parse(document.getElementById(\'book-container\').dataset.pageImages);',
-        'const pageImages = window.__PAGE_IMAGES__;'
     );
 
     return modifiedJs;
@@ -65,19 +59,22 @@ export function wrapFlipbookJs(jsContent) {
 
 /**
  * Generates HTML for individual pages
- * @param {number} pageCount - Total number of pages
+ * @param {string[]} pageImages - Array of base64 image data URLs
  * @returns {string} HTML string for all pages
  */
-export function generatePagesHtml(pageCount) {
-    if (!Number.isInteger(pageCount) || pageCount < 1) {
-        throw new Error('pageCount must be a positive integer');
+export function generatePagesHtml(pageImages) {
+    if (!Array.isArray(pageImages)) {
+        throw new Error('pageImages must be an array');
     }
+
+    const pageCount = pageImages.length;
 
     const pagesHtml = Array.from({ length: pageCount }, (_, i) => {
         const pageNum = i + 1;
+        const imgSrc = pageImages[i]?.replace(/"/g, '&quot;') || '';
         return `            <div class="page" id="page-${pageNum}">
-                <div class="page-face page-face-front"></div>
-                <div class="page-face page-face-back" id="page-${pageNum}-back"></div>
+                <div class="page-face page-face-front"><img src="${imgSrc}" alt="Page ${pageNum}" style="display: none;" /></div>
+                <div class="page-face page-face-back" id="page-${pageNum}-back"><img src="${imgSrc}" alt="Page ${pageNum}" style="display: none;" /></div>
             </div>`;
     }).join('');
 
@@ -86,24 +83,21 @@ export function generatePagesHtml(pageCount) {
 
 /**
  * Generates the complete HTML structure for the flipbook
- * @param {number} pageCount - Total number of pages
  * @param {string[]} pageImages - Array of base64 image data URLs
  * @param {GeneratorOptions} options - Generator options
  * @param {AssetLoader} assetLoader - Asset loader (optional, defaults to file loader)
  * @returns {Promise<string>} Complete HTML document
  */
-export async function generateFlipbookHtml(pageCount, pageImages, options = {}, assetLoader = defaultAssetLoader) {
-    if (!Number.isInteger(pageCount) || pageCount < 1) {
-        throw new Error('pageCount must be a positive integer');
-    }
-
+export async function generateFlipbookHtml(pageImages, options = {}, assetLoader = defaultAssetLoader) {
     if (!Array.isArray(pageImages)) {
         throw new Error('pageImages must be an array');
     }
 
-    if (pageImages.length !== pageCount) {
-        throw new Error('pageImages length must match pageCount');
+    if (pageImages.length < 1) {
+        throw new Error('pageImages must contain at least one image');
     }
+
+    const pageCount = pageImages.length;
 
     const { title = 'Flipbook' } = options;
 
@@ -112,7 +106,7 @@ export async function generateFlipbookHtml(pageCount, pageImages, options = {}, 
         assetLoader.loadJs().catch(() => '')
     ]);
 
-    const pagesHtml = generatePagesHtml(pageCount);
+    const pagesHtml = generatePagesHtml(pageImages);
 
     return `<!DOCTYPE html>
 <html lang="en">
@@ -124,24 +118,16 @@ export async function generateFlipbookHtml(pageCount, pageImages, options = {}, 
 </head>
 <body>
     <div id="flipbook-wrapper">
-        <div id="book-container">
+        <div id="book-container" data-page-count="${pageCount}">
             ${pagesHtml}
         </div>
     </div>
     <script>
         window.__PAGE_COUNT__ = ${pageCount};
-        window.__PAGE_IMAGES__ = ${JSON.stringify(pageImages)};
     </script>
     <script>${js}</script>
 </body>
 </html>`;
 }
 
-/**
- * Legacy function for backward compatibility
- * @deprecated Use generateFlipbookHtml with assetLoader parameter instead
- */
-export async function generateFlipbookHtmlLegacy(pageCount, pageImages, options = {}) {
-    return generateFlipbookHtml(pageCount, pageImages, options, defaultAssetLoader);
-}
 

--- a/test/generator.test.js
+++ b/test/generator.test.js
@@ -21,7 +21,7 @@ function init() { /* ... */ }
 
             const expected = `
 const totalPages = window.__PAGE_COUNT__;
-const pageImages = window.__PAGE_IMAGES__;
+const pageImages = JSON.parse(document.getElementById('book-container').dataset.pageImages);
 function init() { /* ... */ }
 `;
 
@@ -55,36 +55,32 @@ function init() { /* ... */ }
 
     describe('generatePagesHtml', () => {
         it('should generate correct HTML for single page', () => {
-            const result = generatePagesHtml(1);
+            const pageImages = ['data:image/jpeg;base64,test'];
+            const result = generatePagesHtml(pageImages);
             const expected = `            <div class="page" id="page-1">
-                <div class="page-face page-face-front"></div>
-                <div class="page-face page-face-back" id="page-1-back"></div>
+                <div class="page-face page-face-front"><img src="data:image/jpeg;base64,test" alt="Page 1" style="display: none;" /></div>
+                <div class="page-face page-face-back" id="page-1-back"><img src="data:image/jpeg;base64,test" alt="Page 1" style="display: none;" /></div>
             </div>`;
             assert.strictEqual(result, expected);
         });
 
         it('should generate correct HTML for multiple pages', () => {
-            const result = generatePagesHtml(3);
+            const pageImages = ['data:image/jpeg;base64,test1', 'data:image/jpeg;base64,test2', 'data:image/jpeg;base64,test3'];
+            const result = generatePagesHtml(pageImages);
             assert(result.includes('id="page-1"'));
             assert(result.includes('id="page-2"'));
             assert(result.includes('id="page-3"'));
             assert(result.includes('id="page-1-back"'));
             assert(result.includes('id="page-2-back"'));
             assert(result.includes('id="page-3-back"'));
+            assert(result.includes('src="data:image/jpeg;base64,test1"'));
+            assert(result.includes('src="data:image/jpeg;base64,test2"'));
+            assert(result.includes('src="data:image/jpeg;base64,test3"'));
         });
 
-        it('should throw error for invalid pageCount', () => {
-            assert.throws(() => generatePagesHtml(0), {
-                message: 'pageCount must be a positive integer'
-            });
-            assert.throws(() => generatePagesHtml(-1), {
-                message: 'pageCount must be a positive integer'
-            });
-            assert.throws(() => generatePagesHtml(1.5), {
-                message: 'pageCount must be a positive integer'
-            });
-            assert.throws(() => generatePagesHtml('2'), {
-                message: 'pageCount must be a positive integer'
+        it('should throw error for invalid input', () => {
+            assert.throws(() => generatePagesHtml('not an array'), {
+                message: 'pageImages must be an array'
             });
         });
     });
@@ -92,7 +88,7 @@ function init() { /* ... */ }
     describe('generateFlipbookHtml', () => {
         it('should generate complete HTML with default options', async () => {
             const pageImages = ['data:image/jpeg;base64,test1', 'data:image/jpeg;base64,test2'];
-            const result = await generateFlipbookHtml(2, pageImages, {}, mockAssetLoader);
+            const result = await generateFlipbookHtml(pageImages, {}, mockAssetLoader);
 
             // Check basic structure
             assert(result.includes('<!DOCTYPE html>'));
@@ -101,32 +97,28 @@ function init() { /* ... */ }
             assert(result.includes('.test-css { color: red; }'));
             assert(result.includes('console.log("test js");'));
             assert(result.includes('window.__PAGE_COUNT__ = 2'));
-            assert(result.includes('window.__PAGE_IMAGES__ = ["data:image/jpeg;base64,test1","data:image/jpeg;base64,test2"]'));
             assert(result.includes('id="page-1"'));
             assert(result.includes('id="page-2"'));
+            assert(result.includes('<img src="data:image/jpeg;base64,test1"'));
+            assert(result.includes('<img src="data:image/jpeg;base64,test2"'));
         });
 
         it('should generate HTML with custom title', async () => {
             const pageImages = ['data:image/jpeg;base64,test'];
-            const result = await generateFlipbookHtml(1, pageImages, { title: 'My Book' }, mockAssetLoader);
+            const result = await generateFlipbookHtml(pageImages, { title: 'My Book' }, mockAssetLoader);
 
             assert(result.includes('<title>My Book</title>'));
         });
 
         it('should validate input parameters', async () => {
             await assert.rejects(
-                async () => generateFlipbookHtml(0, [], {}, mockAssetLoader),
-                { message: 'pageCount must be a positive integer' }
+                async () => generateFlipbookHtml([], {}, mockAssetLoader),
+                { message: 'pageImages must contain at least one image' }
             );
 
             await assert.rejects(
-                async () => generateFlipbookHtml(1, 'not an array', {}, mockAssetLoader),
+                async () => generateFlipbookHtml('not an array', {}, mockAssetLoader),
                 { message: 'pageImages must be an array' }
-            );
-
-            await assert.rejects(
-                async () => generateFlipbookHtml(2, ['image1'], {}, mockAssetLoader),
-                { message: 'pageImages length must match pageCount' }
             );
         });
 
@@ -137,7 +129,7 @@ function init() { /* ... */ }
             };
 
             const pageImages = ['data:image/jpeg;base64,test'];
-            const result = await generateFlipbookHtml(1, pageImages, {}, failingLoader);
+            const result = await generateFlipbookHtml(pageImages, {}, failingLoader);
 
             assert(result.includes('<style></style>'));
             assert(result.includes('<script></script>'));
@@ -145,24 +137,24 @@ function init() { /* ... */ }
 
         it('should generate valid HTML structure', async () => {
             const pageImages = ['data:image/jpeg;base64,test'];
-            const result = await generateFlipbookHtml(1, pageImages, {}, mockAssetLoader);
+            const result = await generateFlipbookHtml(pageImages, {}, mockAssetLoader);
 
             // Check that all required elements are present
             assert(result.includes('<meta charset="UTF-8">'));
             assert(result.includes('<meta name="viewport"'));
             assert(result.includes('<div id="flipbook-wrapper">'));
-            assert(result.includes('<div id="book-container">'));
+            assert(result.includes('id="book-container"'));
             assert(result.includes('<div class="page" id="page-1">'));
-            assert(result.includes('<div class="page-face page-face-front"></div>'));
-            assert(result.includes('<div class="page-face page-face-back" id="page-1-back"></div>'));
+            assert(result.includes('<div class="page-face page-face-front"><img'));
+            assert(result.includes('<div class="page-face page-face-back" id="page-1-back"><img'));
         });
 
-        it('should escape special characters in JSON', async () => {
+        it('should escape special characters in HTML attributes', async () => {
             const pageImages = ['data:image/jpeg;base64,test"with"quotes'];
-            const result = await generateFlipbookHtml(1, pageImages, {}, mockAssetLoader);
+            const result = await generateFlipbookHtml(pageImages, {}, mockAssetLoader);
 
-            // JSON.stringify should escape quotes properly
-            assert(result.includes('"data:image/jpeg;base64,test\\"with\\"quotes"'));
+            // HTML attribute escaping should convert quotes to &quot;
+            assert(result.includes('data:image/jpeg;base64,test&quot;with&quot;quotes'));
         });
     });
 });


### PR DESCRIPTION
- Update `generateFlipbookHtml` to accept only `pageImages` instead of `pageCount` and `pageImages`.
- Modify `Flipbook` constructor to remove `pageImages` parameter, simplifying the initialization.
- Enhance loading placeholders for images in the flipbook, ensuring proper display during loading.
- Update tests to reflect changes in function signatures and validate new input requirements.